### PR TITLE
Remove deprecated generate_podcast_async_pydantic

### DIFF
--- a/MCP_QUICK_REFERENCE.md
+++ b/MCP_QUICK_REFERENCE.md
@@ -8,7 +8,6 @@
 |------|-------------|---------------|
 | `hello` | Test MCP connection | "Test the MySalonCast connection" |
 | `generate_podcast_async` | Start podcast generation from URL/PDF | "Generate a podcast from https://example.com with Einstein and Curie" |
-| `generate_podcast_async_pydantic` | Start podcast with Pydantic model | Advanced programmatic usage |
 | `get_task_status` | Check generation progress | "What's the status of task task_123?" |
 
 ### 🧹 Management Tools

--- a/MCP_QUICK_REFERENCE.md
+++ b/MCP_QUICK_REFERENCE.md
@@ -8,6 +8,7 @@
 |------|-------------|---------------|
 | `hello` | Test MCP connection | "Test the MySalonCast connection" |
 | `generate_podcast_async` | Start podcast generation from URL/PDF | "Generate a podcast from https://example.com with Einstein and Curie" |
+| ~~`generate_podcast_async_pydantic`~~ | ~~Start podcast with Pydantic model (deprecated)~~ | ~~Advanced programmatic usage~~ |
 | `get_task_status` | Check generation progress | "What's the status of task task_123?" |
 
 ### 🧹 Management Tools

--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -248,39 +248,6 @@ async def generate_podcast_async(
     except Exception as e:
         raise ToolError("Failed to start podcast generation", str(e))
 
-# Async podcast generation with Pydantic model
-@mcp.tool()
-async def generate_podcast_async_pydantic(ctx, request: PodcastRequest) -> dict:
-    """
-    Start async podcast generation using a structured PodcastRequest model.
-    
-    Accepts a complete PodcastRequest object with all configuration options.
-    Use get_task_status with the returned task_id to check progress.
-    
-    Args:
-        request: PodcastRequest model with all generation parameters
-        
-    Returns:
-        Dict with task_id and initial status
-    """
-    # Enhanced logging with MCP context
-    request_id = getattr(ctx, 'request_id', 'unknown')
-    logger.info(f"[{request_id}] MCP Tool 'generate_podcast_async_pydantic' called")
-    logger.info(f"[{request_id}] Request model: {request.model_dump(exclude_none=True)}")
-    
-    try:
-        task_id = await podcast_service.generate_podcast_async(request)
-        logger.info(f"[{request_id}] Async podcast generation started with task_id: {task_id}")
-        
-        return {
-            "success": True,
-            "task_id": task_id,
-            "status": "queued",
-            "message": "Podcast generation started. Use get_task_status to check progress."
-        }
-    except Exception as e:
-        raise ToolError("Failed to start podcast generation", str(e))
-
 # Get status of async task
 @mcp.tool()
 async def get_task_status(ctx, task_id: str) -> dict:

--- a/test_debug_response.py
+++ b/test_debug_response.py
@@ -22,14 +22,15 @@ async def debug_response_format():
         try:
             # Test tool call
             print("📞 Testing tool call...")
-            result = await client.call_tool("generate_podcast_async_pydantic", {
-                "request": {
-                    "prominent_persons": ["Test Person"],
+            result = await client.call_tool(
+                "generate_podcast_async",
+                {
                     "source_urls": ["https://en.wikipedia.org/wiki/Battle_of_Jutland"],
-                    "podcast_duration_minutes": 1,
-                    "language": "en"
-                }
-            })
+                    "prominent_persons": ["Test Person"],
+                    "podcast_length": "1 minute",
+                    "output_language": "en",
+                },
+            )
             
             print(f"Tool result type: {type(result)}")
             print(f"Tool result: {result}")

--- a/test_debug_tool.py
+++ b/test_debug_tool.py
@@ -21,14 +21,15 @@ async def debug_tool_format():
     async with SimpleMCPTestClient() as client:
         try:
             # Generate a task first
-            generate_result = await client.call_tool("generate_podcast_async_pydantic", {
-                "request": {
-                    "prominent_persons": ["Test Person"],
+            generate_result = await client.call_tool(
+                "generate_podcast_async",
+                {
                     "source_urls": ["https://en.wikipedia.org/wiki/Battle_of_Jutland"],
-                    "podcast_duration_minutes": 1,
-                    "language": "en"
-                }
-            })
+                    "prominent_persons": ["Test Person"],
+                    "podcast_length": "1 minute",
+                    "output_language": "en",
+                },
+            )
             
             print(f"Generate result: {generate_result}")
             

--- a/test_job_status_resource.py
+++ b/test_job_status_resource.py
@@ -32,14 +32,15 @@ async def test_job_status_completed_task():
         # Generate a podcast first
         print("📝 Generating podcast for testing...")
         
-        generate_result = await client.call_tool("generate_podcast_async_pydantic", {
-            "request": {
-                "prominent_persons": ["Alan Turing", "Ada Lovelace"],
+        generate_result = await client.call_tool(
+            "generate_podcast_async",
+            {
                 "source_urls": ["https://en.wikipedia.org/wiki/Battle_of_Jutland"],
-                "podcast_duration_minutes": 3,
-                "language": "en"
-            }
-        })
+                "prominent_persons": ["Alan Turing", "Ada Lovelace"],
+                "podcast_length": "3 minutes",
+                "output_language": "en",
+            },
+        )
         
         if not generate_result.get("success"):
             print(f"❌ Failed to generate podcast: {generate_result}")
@@ -149,14 +150,15 @@ async def test_job_status_vs_tool_consistency():
     
     async with SimpleMCPTestClient() as client:
         # Generate a quick test podcast
-        generate_result = await client.call_tool("generate_podcast_async_pydantic", {
-            "request": {
-                "prominent_persons": ["Isaac Newton"],
+        generate_result = await client.call_tool(
+            "generate_podcast_async",
+            {
                 "source_urls": ["https://en.wikipedia.org/wiki/Battle_of_Jutland"],
-                "podcast_duration_minutes": 2,
-                "language": "en"
-            }
-        })
+                "prominent_persons": ["Isaac Newton"],
+                "podcast_length": "2 minutes",
+                "output_language": "en",
+            },
+        )
         
         if not generate_result.get("success"):
             print(f"❌ Failed to generate test podcast: {generate_result}")

--- a/test_job_status_simple.py
+++ b/test_job_status_simple.py
@@ -35,14 +35,15 @@ async def test_simple_job_status():
                 
             # Generate a real task to test with  
             print("\n📝 Generating test podcast...")
-            generate_result = await client.call_tool("generate_podcast_async_pydantic", {
-                "request": {
-                    "prominent_persons": ["Test Person"],
+            generate_result = await client.call_tool(
+                "generate_podcast_async",
+                {
                     "source_urls": ["https://en.wikipedia.org/wiki/Battle_of_Jutland"],
-                    "podcast_duration_minutes": 1,
-                    "language": "en"
-                }
-            })
+                    "prominent_persons": ["Test Person"],
+                    "podcast_length": "1 minute",
+                    "output_language": "en",
+                },
+            )
             
             print(f"Generate result: {generate_result}")
             

--- a/test_mcp_e2e_plan.md
+++ b/test_mcp_e2e_plan.md
@@ -30,12 +30,7 @@ We'll create a Python-based MCP client using the `mcp` package to interact with 
 - Poll status until completion
 - Verify all status transitions
 
-**Test 3: Async Generation with Pydantic Model**
-- Create PodcastRequest object
-- Call `generate_podcast_async_pydantic`
-- Compare behavior with individual params version
-
-**Test 4: Task Status Monitoring**
+**Test 3: Task Status Monitoring**
 - Submit multiple tasks
 - Query status at different stages
 - Verify progress updates

--- a/todo.md
+++ b/todo.md
@@ -233,10 +233,10 @@ This to-do list is broken down for a single LLM coding agent, focusing on action
   - [x] Call `podcast_service.generate_podcast_async()`
   - [x] Return dict with task_id and initial status
   - [x] Handle validation errors gracefully
-- [x] Create `@mcp.tool()` for `generate_podcast_async_pydantic`
-  - [x] Accept PodcastRequest model directly
-  - [x] Pass through to service
-  - [x] Return same format as individual params version
+- [x] ~~Create `@mcp.tool()` for `generate_podcast_async_pydantic` (deprecated)~~
+  - ~~[x] Accept PodcastRequest model directly~~
+  - ~~[x] Pass through to service~~
+  - ~~[x] Return same format as individual params version~~
 - [x] Create `@mcp.tool()` for `get_task_status`
   - [x] Accept task_id parameter
   - [x] Query StatusManager for current status
@@ -253,7 +253,7 @@ This to-do list is broken down for a single LLM coding agent, focusing on action
 
 ## 1.8: End-to-End Testing of Async Tools (P1, M)
 - [x] Test `generate_podcast_async` with various input combinations
-- [ ] Test `generate_podcast_async_pydantic` with PodcastRequest models
+- [ ] ~~Test `generate_podcast_async_pydantic` with PodcastRequest models (deprecated)~~
 - [x] Test `get_task_status` throughout generation lifecycle
 - [x] Test resource access for completed podcasts
 - [x] Test error handling for invalid inputs and failed generations


### PR DESCRIPTION
## Summary
- delete the `generate_podcast_async_pydantic` tool and references
- update tests to use `generate_podcast_async`
- clean up docs mentioning the removed tool
- mark old todo items for the Pydantic tool as deprecated

## Testing
- `pytest test_debug_tool.py test_debug_response.py test_job_status_resource.py test_job_status_simple.py -q` *(fails: ModuleNotFoundError: No module named 'fastmcp')*
- `python start_server.py` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_6841bb3cc4f48321a1a900a46960cb78