### PR TITLE
Fix MCP prompts to match workflow

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -66,31 +66,30 @@ app.add_middleware(OAuthMiddleware)
 
 @mcp.prompt()
 def create_podcast_from_url(
-    url: str, 
-    personas: str = "Einstein, Marie Curie", 
-    length: Literal["short", "medium", "long"] = "medium",
-    language: Literal["en", "es", "fr", "de", "it", "pt", "hi", "ar"] = "en"
+    urls: List[str],
+    personas: str = "Einstein, Marie Curie",
+    length: str = "10 minutes",
 ) -> str:
-    """Generates a prompt template for creating a podcast from a URL with specific personas and length.
+    """Generates a prompt template for creating a podcast from one or more URLs with specific personas and length.
     
     Args:
-        url: The source URL to create a podcast from
+        urls: List of source URLs to create a podcast from
         personas: Comma-separated list of personas/characters for the discussion
-        length: Desired podcast length (short=~5min, medium=~10min, long=~15min)
-        language: Output language for the podcast
+        length: Desired podcast length using a time string (e.g., "10 minutes")
     """
-    return f"""I'd like to create a podcast discussion from this URL: {url}
+    url_list = ", ".join(urls)
+    personas_list = ", ".join([f'"{p.strip()}"' for p in personas.split(",")])
+    return f"""I'd like to create a podcast discussion from these URLs: {url_list}
 
 Please generate a conversational podcast featuring these personas: {personas}
 
 Requirements:
-- Length: {length} (short=~5min, medium=~10min, long=~15min)
-- Language: {language}
+- Length: {length}
 - Style: Natural conversation with different perspectives from each persona
 - Include interesting insights and contrasting viewpoints
 
 Use the MySalonCast tools to:
-1. First, generate the podcast: generate_podcast_async with source_urls=["{url}"], prominent_persons=[{", ".join([f'"{p.strip()}"' for p in personas.split(",")])}], output_language="{language}"
+1. First, generate the podcast: generate_podcast_async with source_urls=[{url_list}], prominent_persons=[{personas_list}], podcast_length="{length}"
 2. Monitor progress with: get_task_status using the returned task_id
 3. Access results via the podcast resources when complete
 
@@ -98,30 +97,26 @@ What aspects of this content would you like the personas to focus on?"""
 
 @mcp.prompt()
 def discuss_persona_viewpoint(
-    task_id: str, 
-    person_id: str, 
-    topic: str
+    task_id: str,
+    person_id: str,
 ) -> str:
-    """Generates a prompt for exploring a specific persona's viewpoint on a topic from their research.
+    """Generate a prompt for exploring a persona's viewpoints from their research.
     
     Args:
         task_id: The podcast generation task ID
-        person_id: The specific persona/person ID to research
-        topic: The topic or aspect to explore
+        person_id: The specific persona/person ID to explore
     """
-    return f"""Let's explore {person_id}'s perspective on "{topic}" from the podcast research.
+    return f"""Let's explore {person_id}'s viewpoints from podcast task {task_id}.
 
-Please use the MySalonCast resources to:
-1. Get the persona research: research://{task_id}/{person_id}
-2. Review their background, expertise, and viewpoints
+Please use the MySalonCast resource:
+research://{task_id}/{person_id}
+to review their detailed_profile and background information.
 
-Based on their research profile, help me understand:
-- How would {person_id} approach this topic "{topic}"?
-- What unique insights would they bring?
-- What questions would they ask?
-- How does their background influence their perspective?
-
-Use the research data to provide specific examples of how {person_id} would discuss "{topic}" in a podcast conversation."""
+Based on that research, help me understand:
+- What key topics are covered in the profile?
+- What viewpoints does {person_id} express about those topics?
+- How does their background influence these perspectives?
+- What questions or follow ups might they raise?"""
 
 @mcp.prompt()
 def analyze_podcast_content(

--- a/test_mcp_integration.py
+++ b/test_mcp_integration.py
@@ -88,10 +88,9 @@ async def step1_prompt_guided_setup(ctx: IntegrationTestContext) -> bool:
         
         # Generate prompt guidance
         ctx.prompt_result = create_podcast_from_url(
-            url=TEST_URLS[0],  # Primary URL for the prompt
+            urls=TEST_URLS,
             personas=personas_str,
-            length="medium",
-            language="en"
+            length="10 minutes"
         )
         
         print(f"\n🎯 Generated Prompt Guidance:")

--- a/test_mcp_prompts.py
+++ b/test_mcp_prompts.py
@@ -27,7 +27,7 @@ async def test_create_podcast_from_url_prompt():
     print("\n🧪 Testing create_podcast_from_url prompt...")
     
     # Test with default parameters
-    result1 = create_podcast_from_url("https://example.com/article")
+    result1 = create_podcast_from_url(["https://example.com/article"])
     
     # Verify the prompt contains key elements
     if "https://example.com/article" not in result1:
@@ -46,22 +46,17 @@ async def test_create_podcast_from_url_prompt():
     
     # Test with custom parameters
     result2 = create_podcast_from_url(
-        "https://research.com/quantum",
+        ["https://research.com/quantum"],
         personas="Tesla, Feynman, Hawking",
-        length="long",
-        language="es"
+        length="15 minutes"
     )
     
     if "Tesla, Feynman, Hawking" not in result2:
         print("❌ Custom personas not properly included")
         return False
     
-    if "long" not in result2:
+    if "15 minutes" not in result2:
         print("❌ Length parameter not included")
-        return False
-    
-    if 'output_language="es"' not in result2:
-        print("❌ Language parameter not properly formatted")
         return False
     
     print("✅ Custom parameters test passed")
@@ -75,9 +70,8 @@ async def test_discuss_persona_viewpoint_prompt():
     
     task_id = f"test_task_{test_run_suffix}"
     person_id = "albert-einstein"
-    topic = "quantum entanglement"
-    
-    result = discuss_persona_viewpoint(task_id, person_id, topic)
+
+    result = discuss_persona_viewpoint(task_id, person_id)
     
     # Verify key elements are included
     if task_id not in result:
@@ -88,9 +82,6 @@ async def test_discuss_persona_viewpoint_prompt():
         print("❌ Person ID not properly included")
         return False
     
-    if topic not in result:
-        print("❌ Topic not properly included")
-        return False
     
     if f"research://{task_id}/{person_id}" not in result:
         print("❌ Resource URL not properly formatted")
@@ -101,7 +92,7 @@ async def test_discuss_persona_viewpoint_prompt():
         return False
     
     print("✅ Persona viewpoint prompt test passed")
-    print(f"   🎭 Generated prompt for {person_id} on '{topic}'")
+    print(f"   🎭 Generated prompt for {person_id}")
     print(f"   📄 Prompt length: {len(result)} characters")
     
     return True
@@ -168,20 +159,12 @@ async def test_prompt_parameter_validation():
     print("\n🧪 Testing prompt parameter validation...")
     
     try:
-        # Test valid language parameter
-        result1 = create_podcast_from_url("https://test.com", language="fr")
-        if 'output_language="fr"' not in result1:
-            print("❌ Valid language parameter not handled correctly")
-            return False
-        
-        print("✅ Valid language parameter test passed")
-        
         # Test valid length parameter
-        result2 = create_podcast_from_url("https://test.com", length="short")
-        if "short" not in result2:
+        result1 = create_podcast_from_url(["https://test.com"], length="7 minutes")
+        if "7 minutes" not in result1:
             print("❌ Valid length parameter not handled correctly")
             return False
-        
+
         print("✅ Valid length parameter test passed")
         
         # Note: Type validation is handled by FastMCP automatically through function signatures
@@ -198,7 +181,7 @@ async def test_prompt_integration_guidance():
     print("\n🧪 Testing prompt integration guidance...")
     
     # Test that create_podcast_from_url includes proper tool usage guidance
-    result1 = create_podcast_from_url("https://example.com")
+    result1 = create_podcast_from_url(["https://example.com"])
     
     guidance_elements = [
         "generate_podcast_async",
@@ -217,12 +200,12 @@ async def test_prompt_integration_guidance():
     
     # Test that discuss_persona_viewpoint includes resource usage guidance
     task_id = f"test_task_{test_run_suffix}"
-    result2 = discuss_persona_viewpoint(task_id, "einstein", "relativity")
+    result2 = discuss_persona_viewpoint(task_id, "einstein")
     
     resource_elements = [
         f"research://{task_id}/einstein",
-        "MySalonCast resources",
-        "research data"
+        "MySalonCast resource",
+        "detailed_profile"
     ]
     
     for element in resource_elements:


### PR DESCRIPTION
## Summary
- update `create_podcast_from_url` to accept multiple URLs and use time string length
- drop language option from prompt content
- adjust `discuss_persona_viewpoint` to use existing persona research
- update tests for new parameters

## Testing
- `python test_mcp_prompts.py`


------
https://chatgpt.com/codex/tasks/task_e_6841cebb8b248321989a37f5726e9eef