### PR TITLE
Remove invalid params from podcast async tool

### DIFF
--- a/app/mcp_server.py
+++ b/app/mcp_server.py
@@ -181,16 +181,19 @@ async def generate_podcast_async(
     source_pdf_path: Optional[str] = None,
     prominent_persons: Optional[List[str]] = None,
     custom_prompt: Optional[str] = None,
-    podcast_name: Optional[str] = None,
-    podcast_tagline: Optional[str] = None,
-    output_language: Literal["en", "es", "fr", "de", "it", "pt", "hi", "ar"] = "en",
-    dialogue_style: Literal["interview", "conversation", "debate", "educational"] = "conversation",
     podcast_length: str = "5-7 minutes",  # Accept time strings like "7 minutes", "5-7 minutes", etc.
-    ending_message: Optional[str] = None
 ) -> dict:
     """
     Generate a podcast asynchronously using provided sources.
     Returns immediately with a task ID for status tracking.
+
+    Args:
+        ctx: MCP request context for correlation.
+        source_urls: Optional list of article URLs.
+        source_pdf_path: Optional PDF source path.
+        prominent_persons: Optional list of personas to feature.
+        custom_prompt: Optional custom instructions for the outline.
+        podcast_length: Desired episode length string.
     """
     # Enhanced logging with MCP context
     request_id = getattr(ctx, 'request_id', 'unknown')
@@ -198,7 +201,9 @@ async def generate_podcast_async(
     
     logger.info(f"[{request_id}] MCP Tool 'generate_podcast_async' called")
     logger.info(f"[{request_id}] Client info: {client_info}")
-    logger.info(f"[{request_id}] Request params: sources={len(source_urls or [])}, persons={len(prominent_persons or [])}, style={dialogue_style}, length={podcast_length}")
+    logger.info(
+        f"[{request_id}] Request params: sources={len(source_urls or [])}, persons={len(prominent_persons or [])}, length={podcast_length}"
+    )
     
     # Basic input validation
     if not source_urls and not source_pdf_path:

--- a/test_mcp_e2e_plan.md
+++ b/test_mcp_e2e_plan.md
@@ -110,10 +110,7 @@ test_cases = [
         "name": "Custom Configuration",
         "params": {
             "source_urls": ["https://example.com"],
-            "podcast_name": "Test Podcast",
-            "podcast_tagline": "Testing MCP Integration",
-            "output_language": "es",
-            "dialogue_style": "formal"
+            "podcast_length": "3-5 minutes"
         }
     }
 ]
@@ -136,12 +133,12 @@ error_cases = [
         "expected_error": "Cannot provide both"
     },
     {
-        "name": "Invalid Language",
+        "name": "Invalid Configuration",
         "params": {
             "source_urls": ["https://example.com"],
-            "output_language": "xyz"
+            "source_pdf_path": "/path/to/file.pdf"
         },
-        "expected_error": "Unsupported language"
+        "expected_error": "Cannot provide both"
     }
 ]
 ```

--- a/tests/mcp/test_async_tools.py
+++ b/tests/mcp/test_async_tools.py
@@ -54,13 +54,9 @@ class MCPToolTester:
                 source_urls=source_urls or None,
                 source_pdf_path=source_pdf_path or None,
                 prominent_persons=kwargs.get("prominent_persons"),
-                custom_prompt=kwargs.get("custom_prompt"),
-                podcast_name=kwargs.get("podcast_name"),
-                podcast_tagline=kwargs.get("podcast_tagline"),
-                output_language=kwargs.get("output_language", "en"),
-                dialogue_style=kwargs.get("dialogue_style", "casual"),
-                podcast_length=kwargs.get("podcast_length", "5-8 minutes"),
-                webhook_url=kwargs.get("webhook_url")
+                custom_prompt_for_outline=kwargs.get("custom_prompt"),
+                desired_podcast_length_str=kwargs.get("podcast_length", "5-8 minutes"),
+                webhook_url=kwargs.get("webhook_url"),
             )
         except Exception as e:
             return {
@@ -130,9 +126,6 @@ async def test_full_workflow():
     test_params = {
         "source_urls": ["https://en.wikipedia.org/wiki/Artificial_intelligence"],
         "podcast_length": "3-5 minutes",
-        "podcast_name": "AI Today",
-        "podcast_tagline": "Understanding artificial intelligence",
-        "dialogue_style": "casual"
     }
     
     result = await tester.test_generate_podcast_async(**test_params)
@@ -176,12 +169,6 @@ async def test_full_workflow():
     )
     logger.info("Both sources result: %s", json.dumps(result, indent=2))
     
-    # Invalid language
-    result = await tester.test_generate_podcast_async(
-        source_urls=["https://example.com"],
-        output_language="xyz"
-    )
-    logger.info("Invalid language result: %s", json.dumps(result, indent=2))
     
     # Test 4: Non-existent task
     logger.info("\n=== Test 4: Non-existent Task ===")

--- a/tests/mcp/test_cleanup_with_real_task.py
+++ b/tests/mcp/test_cleanup_with_real_task.py
@@ -67,10 +67,7 @@ async def test_cleanup_with_generated_task():
             "generate_podcast_async",
             {
                 "source_urls": [content_url],
-                "podcast_name": "AI Content Creation Test",
-                "dialogue_style": "casual",
                 "podcast_length": "1-2 minutes",
-                "output_language": "en"
             }
         )
         

--- a/tests/mcp/test_mcp_client.py
+++ b/tests/mcp/test_mcp_client.py
@@ -123,11 +123,11 @@ async def test_generate_podcast_async():
         # Create a podcast generation request
         print("Creating async podcast generation request...")
         payload = {
-            "source_urls": ["https://www.example.com/sample", "https://www.example.org/test"],
-            "podcast_name": "Test Podcast",
+            "source_urls": [
+                "https://www.example.com/sample",
+                "https://www.example.org/test",
+            ],
             "podcast_length": "3-5 minutes",
-            "output_language": "en",  
-            "dialogue_style": "conversational"
         }
         
         # Submit the request using the updated client

--- a/tests/mcp/test_mcp_tools_subprocess.py
+++ b/tests/mcp/test_mcp_tools_subprocess.py
@@ -81,9 +81,7 @@ async def test():
     # Create a simple request
     request = PodcastRequest(
         source_urls=["https://en.wikipedia.org/wiki/Machine_learning"],
-        podcast_length="3-5 minutes",
-        podcast_name="ML Quick Insights",
-        dialogue_style="casual"
+        desired_podcast_length_str="3-5 minutes",
     )
     
     # Submit async task
@@ -123,15 +121,7 @@ import logging
 logging.basicConfig(level=logging.WARNING)
 
 async def test():
-    # Test invalid language
-    try:
-        request = PodcastRequest(
-            source_urls=["https://example.com"],
-            output_language="xyz"  # Invalid language
-        )
-        print("ERROR: Should have raised validation error for invalid language")
-    except Exception as e:
-        print(f"✓ Correctly caught validation error: {type(e).__name__}")
+
     
     # Test no sources
     try:


### PR DESCRIPTION
## Summary
- simplify generate_podcast_async tool parameters
- update async tool tests
- adjust cleanup example and e2e plan docs

## Testing
- `pytest tests/test_validations.py::test_is_valid_url -q`
- `python start_server.py` *(fails: ModuleNotFoundError: No module named 'pdfplumber')*

------
https://chatgpt.com/codex/tasks/task_e_6841dedfa8d88321b7b2625579280fa4