### PR TITLE
Enable Pydantic AI flag support

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -42,6 +42,11 @@ class Config:
     def gemini_api_key(self) -> Optional[str]:
         """Get Gemini API key from environment variables."""
         return os.getenv("GEMINI_API_KEY")
+
+    @property
+    def use_pydantic_ai(self) -> bool:
+        """Feature flag to enable Pydantic AI integration."""
+        return os.getenv("USE_PYDANTIC_AI", "false").lower() == "true"
     
     @property
     def audio_bucket(self) -> Optional[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,3 +68,5 @@ urllib3==2.4.0
 uvicorn==0.24.0
 websockets==15.0.1
 youtube-transcript-api==1.0.3
+pydantic-ai==0.2.15
+logfire==3.18.0

--- a/requirements_clean.txt
+++ b/requirements_clean.txt
@@ -45,3 +45,5 @@ requests>=2.32.0
 rich>=14.0.0
 typer>=0.16.0
 tenacity>=9.1.0
+pydantic-ai>=0.2.0
+logfire>=3.18.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,18 @@
+import os
+import importlib
+from app.config import Config
+
+def test_use_pydantic_ai_flag(monkeypatch):
+    monkeypatch.setenv("USE_PYDANTIC_AI", "true")
+    cfg = Config()
+    assert cfg.use_pydantic_ai is True
+    monkeypatch.setenv("USE_PYDANTIC_AI", "false")
+    cfg = Config()
+    assert cfg.use_pydantic_ai is False
+
+
+def test_pydantic_ai_importable():
+    try:
+        import pydantic_ai  # noqa: F401
+    except Exception as e:
+        raise AssertionError(f"Failed to import pydantic_ai: {e}")


### PR DESCRIPTION
## Summary
- add `pydantic-ai` and `logfire` dependencies
- expose `USE_PYDANTIC_AI` flag via `Config`
- test that the flag and dependency work

## Testing
- `pytest -q`
- `PYTHONPATH=. python scripts/start_server.py >/tmp/server.log 2>&1 &`

------
https://chatgpt.com/codex/tasks/task_e_68425a54b6988321b35063f9e4e76fdd